### PR TITLE
add exclude path /var/lib

### DIFF
--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(06)regular.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(06)regular.yml
@@ -100,20 +100,19 @@
   changed_when: False
   check_mode: no
 
+# /var/lib can contain:
+# - systemd DynamicUsers
+# - docker volumes
 - name: req-69.1 No files and directories without assigned user or group must exist.
-  shell: find / -nouser 2>/dev/null
+  shell: find / -not -path "/var/lib/*" -nouser 2>/dev/null
   register: files_no_user
   failed_when:
     - files_no_user.stdout != ''
-    # relates to ownership and drop of use of `DynamicUser` in systemd
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918190
-    # https://github.com/systemd/systemd/pull/11356/files
-    - "'/var/lib/private/systemd/timesync' not in files_no_user.split('\n')|d([])"
   changed_when: False
   check_mode: no
 
 - name: req-69.2 No files and directories without assigned user or group must exist.
-  shell: find / -nogroup 2>/dev/null
+  shell: find / -not -path "/var/lib/*" -nogroup 2>/dev/null
   register: files_no_group
   failed_when:
     - files_no_group.stdout != ''


### PR DESCRIPTION
Exclude `/var/lib` because of process using dynamic, low priv users e.g.:
- `/var/lib/docker/*`
-  `/var/lib/private/systemd/*` 

